### PR TITLE
move testing framework to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   ],
   "homepage": "http://pthurlow.github.com/triejs",
   "contibutors": [],
-  "dependencies": {
-    "foounit": ""
-  },
+  "dependencies": {},
   "scripts": {
     "test": "node tests/vendor/suite.js"
   },
@@ -22,7 +20,9 @@
     "type": "git",
     "url": "git://github.com/pthurlow/triejs.git"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "foounit": "0.1.2"
+  },
   "engines": {
     "node": "*"
   }


### PR DESCRIPTION
foounit has not been updated for 4 years now. It depends on some old modules that can cause errors when trying to install with a modern version of node.

```
npm install triejs
npm ERR! Darwin 15.3.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "triejs"
npm ERR! node v5.7.0
npm ERR! npm  v3.6.0
npm ERR! code ENOTSUP

npm ERR! notsup Unsupported engine for connect@1.8.5: wanted: {"node":">= 0.4.1 < 0.7.0"} (current: {"node":"5.7.0","npm":"3.6.0"})
npm ERR! notsup Not compatible with your version of node/npm: connect@1.8.5
npm ERR! notsup Not compatible with your version of node/npm: connect@1.8.5
npm ERR! notsup Required: {"node":">= 0.4.1 < 0.7.0"}
npm ERR! notsup Actual:   {"npm":"3.6.0","node":"5.7.0"}
```

This change moves the foounit dependency to `devDependencies` instead, so the testing framework is not required when using this module.
